### PR TITLE
Feature/add api services

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL = "Base/API/url"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.*
 *.tsbuildinfo
 
 app-example
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
+        "axios": "^1.8.4",
         "expo": "~52.0.40",
         "expo-blur": "~14.0.3",
         "expo-constants": "~17.0.8",
@@ -44,7 +45,8 @@
         "react-native-svg": "^15.2.0",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5",
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17",
+        "zod": "^3.24.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -5162,6 +5164,32 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -8046,6 +8074,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -13323,6 +13371,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -16511,6 +16565,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "@gluestack-ui/overlay": "^0.1.22",
     "@gluestack-ui/textarea": "^0.1.25",
     "@gluestack-ui/toast": "^1.0.9",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
+    "axios": "^1.8.4",
     "expo": "~52.0.40",
     "expo-blur": "~14.0.3",
     "expo-constants": "~17.0.8",
@@ -59,7 +61,7 @@
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
     "tailwindcss": "^3.4.17",
-    "@react-native-async-storage/async-storage": "1.23.1"
+    "zod": "^3.24.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/server/accommodation .ts
+++ b/services/server/accommodation .ts
@@ -1,0 +1,73 @@
+import {
+  AccommodationResponse,
+  AccommodationPost,
+  AccommodationPatch,
+  AccommodationResponseSchema,
+} from "../../types/zod/accommodation";
+import { APIService } from "./api";
+
+export class AccommodationService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async getAllAccommodations(): Promise<AccommodationResponse[]> {
+    try {
+      const response = await this.get<any[]>(`/accommodations`);
+      return response.data.map((accommodation) =>
+        AccommodationResponseSchema.parse(accommodation),
+      );
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async createAccommodation(
+    data: AccommodationPost,
+  ): Promise<AccommodationResponse> {
+    try {
+      const response = await this.post<AccommodationPost, any>(
+        `/accommodations/`,
+        data,
+      );
+      return AccommodationResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async getAccommodationById(id: number): Promise<AccommodationResponse> {
+    try {
+      const response = await this.get<any>(`/accommodations/${id}`);
+      return AccommodationResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async updateAccommodationById(
+    id: number,
+    data: AccommodationPatch,
+  ): Promise<AccommodationResponse> {
+    try {
+      const response = await this.patch<AccommodationPatch, any>(
+        `/accommodations/${id}`,
+        data,
+      );
+      return AccommodationResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async deleteAccommodationById(id: number) {
+    try {
+      const response = await this.delete(`/accommodations/${id}`);
+      if (response.status !== 204) {
+        throw new Error("Failed to delete accommodation.");
+      }
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/services/server/api.ts
+++ b/services/server/api.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+
+export abstract class APIService {
+  private axiosInstance: AxiosInstance;
+
+  constructor() {
+    this.axiosInstance = axios.create({
+      baseURL: process.env.EXPO_PUBLIC_API_BASE_URL,
+    });
+  }
+
+  get<ResponseType>(url: string): Promise<AxiosResponse<ResponseType>> {
+    return this.axiosInstance.get(url);
+  }
+
+  post<RequestType, ResponseType>(
+    url: string,
+    data: RequestType,
+  ): Promise<AxiosResponse<ResponseType>> {
+    return this.axiosInstance.post(url, data);
+  }
+
+  patch<RequestType, ResponseType>(
+    url: string,
+    data: RequestType,
+  ): Promise<AxiosResponse<ResponseType>> {
+    return this.axiosInstance.patch(url, data);
+  }
+
+  delete(url: string) {
+    return this.axiosInstance.delete(url);
+  }
+
+  request<T>(config: AxiosRequestConfig = {}): Promise<AxiosResponse<T>> {
+    return this.axiosInstance(config);
+  }
+}

--- a/services/server/auth.ts
+++ b/services/server/auth.ts
@@ -1,0 +1,32 @@
+import {
+  Register,
+  Login,
+  LoginResponse,
+  LoginResponseSchema,
+} from "../../types/zod/auth";
+import { UserResponse, UserResponseSchema } from "../../types/zod/user";
+import { APIService } from "./api";
+
+export class AuthService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async register(data: Register): Promise<UserResponse> {
+    try {
+      const response = await this.post<Register, any>(`/auth/register/`, data);
+      return UserResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async login(data: Login): Promise<LoginResponse> {
+    try {
+      const response = await this.post<Login, any>(`/auth/login/`, data);
+      return LoginResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/services/server/event.ts
+++ b/services/server/event.ts
@@ -1,0 +1,72 @@
+import {
+  EventResponse,
+  EventPost,
+  EventPatch,
+  EventResponseSchema,
+} from "../../types/zod/event";
+import { APIService } from "./api";
+
+export class EventService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async getAllEvents(): Promise<EventResponse[]> {
+    try {
+      const response = await this.get<any[]>(`/events`);
+      return response.data.map((event) => EventResponseSchema.parse(event));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async createEvent(data: EventPost): Promise<EventResponse> {
+    try {
+      const response = await this.post<EventPost, any>(`/events/`, data);
+      return EventResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async getEventById(id: number): Promise<EventResponse> {
+    try {
+      const response = await this.get<any>(`/events/${id}`);
+      return EventResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async updateEventById(id: number, data: EventPatch): Promise<EventResponse> {
+    try {
+      const response = await this.patch<EventPatch, any>(`/events/${id}`, data);
+      return EventResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async deleteEventById(id: number) {
+    try {
+      const response = await this.delete(`/events/${id}`);
+      if (response.status !== 204) {
+        throw new Error("Failed to delete event.");
+      }
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async filterEvents(
+    filters: Record<string, any> = {},
+  ): Promise<EventResponse[]> {
+    try {
+      const query = new URLSearchParams(filters).toString();
+      const response = await this.get<any[]>(`/events/filter?${query}`);
+      return response.data.map((event) => EventResponseSchema.parse(event));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/services/server/refund.ts
+++ b/services/server/refund.ts
@@ -1,0 +1,81 @@
+import {
+  RefundResponse,
+  RefundBatchPost,
+  RefundPatch,
+  RefundResponseSchema,
+} from "../../types/zod/refund";
+import { APIService } from "./api";
+
+export class RefundService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async getAllRefunds(): Promise<RefundResponse[]> {
+    try {
+      const response = await this.get<any[]>(`/refunds`);
+      return response.data.map((refund) => RefundResponseSchema.parse(refund));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async createRefunds(data: RefundBatchPost): Promise<RefundResponse[]> {
+    try {
+      const response = await this.post<RefundBatchPost, any[]>(
+        `/refunds/`,
+        data,
+      );
+      return response.data.map((refund) => RefundResponseSchema.parse(refund));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async getRefundById(id: number): Promise<RefundResponse> {
+    try {
+      const response = await this.get<any>(`/refunds/${id}`);
+      return RefundResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async updateRefundById(
+    id: number,
+    data: RefundPatch,
+  ): Promise<RefundResponse> {
+    try {
+      const response = await this.patch<RefundPatch, any>(
+        `/refunds/${id}`,
+        data,
+      );
+      return RefundResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async deleteRefundById(id: number) {
+    try {
+      const response = await this.delete(`/refunds/${id}`);
+      if (response.status !== 204) {
+        throw new Error("Failed to delete refund.");
+      }
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async filterRefunds(
+    filters: Record<string, any> = {},
+  ): Promise<RefundResponse[]> {
+    try {
+      const query = new URLSearchParams(filters).toString();
+      const response = await this.get<any[]>(`/refunds/filter?${query}`);
+      return response.data.map((refund) => RefundResponseSchema.parse(refund));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/services/server/task.ts
+++ b/services/server/task.ts
@@ -1,0 +1,72 @@
+import {
+  TaskResponse,
+  TaskPost,
+  TaskPatch,
+  TaskResponseSchema,
+} from "../../types/zod/task";
+import { APIService } from "./api";
+
+export class TaskService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async getAllTasks(): Promise<TaskResponse[]> {
+    try {
+      const response = await this.get<any[]>(`/tasks`);
+      return response.data.map((task) => TaskResponseSchema.parse(task));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async createTask(data: TaskPost): Promise<TaskResponse> {
+    try {
+      const response = await this.post<TaskPost, any>(`/tasks/`, data);
+      return TaskResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async getTaskById(id: number): Promise<TaskResponse> {
+    try {
+      const response = await this.get<any>(`/tasks/${id}`);
+      return TaskResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async updateTaskById(id: number, data: TaskPatch): Promise<TaskResponse> {
+    try {
+      const response = await this.patch<TaskPatch, any>(`/tasks/${id}`, data);
+      return TaskResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async deleteTaskById(id: number) {
+    try {
+      const response = await this.delete(`/tasks/${id}`);
+      if (response.status !== 204) {
+        throw new Error("Failed to delete task.");
+      }
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async filterTasks(
+    filters: Record<string, any> = {},
+  ): Promise<TaskResponse[]> {
+    try {
+      const query = new URLSearchParams(filters).toString();
+      const response = await this.get<any[]>(`/tasks/filter?${query}`);
+      return response.data.map((task) => TaskResponseSchema.parse(task));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/services/server/user.ts
+++ b/services/server/user.ts
@@ -1,0 +1,62 @@
+import {
+  UserResponse,
+  UserPatch,
+  UserResponseSchema,
+} from "../../types/zod/user";
+import { APIService } from "./api";
+
+export class UserService extends APIService {
+  constructor() {
+    super();
+  }
+
+  async getAllUsers(): Promise<UserResponse[]> {
+    try {
+      const response = await this.get<any[]>(`/users`);
+      return response.data.map((user) => UserResponseSchema.parse(user));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async getUserById(id: number): Promise<UserResponse> {
+    try {
+      const response = await this.get<any>(`/users/${id}`);
+      return UserResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async updateUserById(id: number, data: UserPatch): Promise<UserResponse> {
+    try {
+      const response = await this.patch<UserPatch, any>(`/users/${id}`, data);
+      return UserResponseSchema.parse(response.data);
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async deleteUserById(id: number) {
+    try {
+      const response = await this.delete(`/users/${id}`);
+      if (response.status !== 204) {
+        throw new Error("Failed to delete user.");
+      }
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+
+  async filterUsers(
+    filters: Record<string, any> = {},
+  ): Promise<UserResponse[]> {
+    try {
+      const query = new URLSearchParams(filters).toString();
+      const response = await this.get<any[]>(`/users/filter?${query}`);
+      return response.data.map((user) => UserResponseSchema.parse(user));
+    } catch (error: any) {
+      throw error?.response?.data || new Error("Unknown error occurred.");
+    }
+  }
+}

--- a/types/zod/accommodation.ts
+++ b/types/zod/accommodation.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const BaseAccommodationSchema = z.object({
+  name: z.string(),
+  code: z.string(),
+  location: z.string(),
+  postalCode: z.number(),
+  country: z.string(),
+});
+
+export const AccommodationPostSchema = BaseAccommodationSchema;
+
+export const AccommodationResponseSchema = AccommodationPostSchema.extend({
+  _id: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const AccommodationPatchSchema = AccommodationPostSchema.partial();
+
+export type AccommodationPost = z.infer<typeof AccommodationPostSchema>;
+export type AccommodationResponse = z.infer<typeof AccommodationResponseSchema>;
+export type AccommodationPatch = z.infer<typeof AccommodationPatchSchema>;

--- a/types/zod/auth.ts
+++ b/types/zod/auth.ts
@@ -10,9 +10,7 @@ export const BaseLoginSchema = z.object({
 
 export const LoginSchema = BaseLoginSchema;
 
-export const LoginResponseSchema = z.object({
-  token: z.string(),
-});
+export const LoginResponseSchema = z.string();
 
 export type Register = z.infer<typeof RegisterSchema>;
 export type Login = z.infer<typeof LoginSchema>;

--- a/types/zod/auth.ts
+++ b/types/zod/auth.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { BaseUserSchema } from "./user";
+
+export const RegisterSchema = BaseUserSchema;
+
+export const BaseLoginSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});
+
+export const LoginSchema = BaseLoginSchema;
+
+export const LoginResponseSchema = z.object({
+  token: z.string(),
+});
+
+export type Register = z.infer<typeof RegisterSchema>;
+export type Login = z.infer<typeof LoginSchema>;
+export type LoginResponse = z.infer<typeof LoginResponseSchema>;

--- a/types/zod/event.ts
+++ b/types/zod/event.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const BaseEventSchema = z.object({
+  title: z.string(),
+  description: z.string().nullable(),
+  plannedDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+});
+
+export const EventPostSchema = BaseEventSchema.extend({
+  userId: z.string(),
+  accommodationId: z.string(),
+});
+
+export const EventResponseSchema = EventPostSchema.extend({
+  _id: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const EventPatchSchema = BaseEventSchema.partial();
+
+export type EventPost = z.infer<typeof EventPostSchema>;
+export type EventResponse = z.infer<typeof EventResponseSchema>;
+export type EventPatch = z.infer<typeof EventPatchSchema>;

--- a/types/zod/refund.ts
+++ b/types/zod/refund.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const BaseRefundSchema = z.object({
+  title: z.string(),
+  toRefund: z.number(),
+  done: z.boolean(),
+});
+
+export const RefundBatchPostSchema = z.object({
+  title: z.string(),
+  toSplit: z.number(),
+  userId: z.string(),
+  roommateIds: z.string().array(),
+});
+
+export const RefundResponseSchema = BaseRefundSchema.extend({
+  _id: z.string(),
+  userId: z.string(),
+  roommateId: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const RefundPatchSchema = BaseRefundSchema.partial();
+
+export type RefundBatchPost = z.infer<typeof RefundBatchPostSchema>;
+export type RefundResponse = z.infer<typeof RefundResponseSchema>;
+export type RefundPatch = z.infer<typeof RefundPatchSchema>;

--- a/types/zod/rule.ts
+++ b/types/zod/rule.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const BaseRuleSchema = z.object({
+  title: z.string(),
+  description: z.string().nullable(),
+});
+
+export const RulePostSchema = BaseRuleSchema.extend({
+  accommodationId: z.string(),
+});
+
+export const RuleResponseSchema = RulePostSchema.extend({
+  _id: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const RulePatchSchema = BaseRuleSchema.partial();
+
+export type RulePost = z.infer<typeof RulePostSchema>;
+export type RuleResponse = z.infer<typeof RuleResponseSchema>;
+export type RulePatch = z.infer<typeof RulePatchSchema>;

--- a/types/zod/task.ts
+++ b/types/zod/task.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const BaseTaskSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+});
+
+export const TaskPostSchema = BaseTaskSchema.extend({
+  userId: z.string(),
+  accommodationId: z.string(),
+});
+
+export const TaskResponseSchema = TaskPostSchema.extend({
+  _id: z.string(),
+  done: z.boolean(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const TaskPatchSchema = BaseTaskSchema.extend({
+  done: z.boolean(),
+}).partial();
+
+export type TaskPost = z.infer<typeof TaskPostSchema>;
+export type TaskResponse = z.infer<typeof TaskResponseSchema>;
+export type TaskPatch = z.infer<typeof TaskPatchSchema>;

--- a/types/zod/user.ts
+++ b/types/zod/user.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const BaseUserSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  username: z.string(),
+  password: z.string().min(8),
+  age: z.number().min(0),
+  description: z.string().nullable(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+});
+
+export const UserResponseSchema = BaseUserSchema.extend({
+  _id: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const UserPatchSchema = BaseUserSchema.partial();
+
+export type UserResponse = z.infer<typeof UserResponseSchema>;
+export type UserPatch = z.infer<typeof UserPatchSchema>;


### PR DESCRIPTION
Dans cette PR il y a :

- la création des Schémas Zod, validateur de données de formulaire et d'API, et les typages TypeScript à partir de ces schémas (particularité de Zod vis-à-vis des autres validateurs de données et raison pour laquelle il est pratiquement toujours utilisé lorsque TypeScript est utilisé)

- les services API qui permettent d'appeler direct une fonction qui va appeler le endpoint au lieu de faire des axios partout. Aussi utilisé car c'est de la POO, qui est un critère de l'exam RNCP.

PS: pour zod, au niveau des formulaires, on peut utiliser un react-hook-form et zodResolver qui vont permettre de faire la validation en temps réel des inputs et écrire les messages d'erreur quand ils sont pas bon. Pour les données du backend, il suffit de faire un schema.parse(data), qui renvoit une erreur si l'objet n'est pas bon et sinon renvoit l'objet avec son type TypeScript. Les schémas peuvent être "extend", qui permet d'appeler les champs d'un autre schéma et d'ajouter des champs en plus, ou devenir "partial" pour que les champs soient optionnels (patch). Avec z.infer, c'est schéma sont convertis en type TypeScript.