### PR TITLE
refactor: replace HStack with VStack for button layout in login/register

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -99,25 +99,21 @@ export default function LoginScreen() {
           )}
         </FormControl>
 
-        <View className="flex flex-row gap-x-4">
-          <Button
-            className="rounded-md"
-            size="md"
-            onPress={handleSubmit(onSubmit)}
-          >
+        <VStack space="sm">
+          <Button variant="solid" size="md" onPress={handleSubmit(onSubmit)}>
             <ButtonText>Sign In</ButtonText>
           </Button>
           <Button
             className=""
             size="md"
-            variant="link"
+            variant="outline"
             onPress={() => {
               router.replace("/register");
             }}
           >
             <ButtonText>Sign Up</ButtonText>
           </Button>
-        </View>
+        </VStack>
       </VStack>
     </Center>
   );

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -173,25 +173,21 @@ export default function RegisterPage() {
             )}
           </FormControl>
 
-          <HStack space="lg">
-            <Button
-              className=" rounded-md"
-              size="md"
-              onPress={handleSubmit(onSubmit)}
-            >
+          <VStack space="sm">
+            <Button variant="solid" size="md" onPress={handleSubmit(onSubmit)}>
               <ButtonText>Sign Up</ButtonText>
             </Button>
             <Button
               className=""
               size="md"
-              variant="link"
+              variant="outline"
               onPress={() => {
                 router.replace("/login");
               }}
             >
               <ButtonText>Sign In</ButtonText>
             </Button>
-          </HStack>
+          </VStack>
         </VStack>
       </Center>
     </SafeAreaView>


### PR DESCRIPTION
This pull request refactors the layout and styling of buttons in the `LoginScreen` and `RegisterPage` components to improve consistency and alignment. The changes replace the horizontal layout with a vertical stack and adjust button variants for better visual clarity.

**Layout and Styling Updates:**

* [`app/login.tsx`](diffhunk://#diff-591565fa0176081f85d19df59ad66edd7c2c213096e3ac37d4a8585da61f7290L102-R116): Replaced the `View` component with a `VStack` for vertical alignment of buttons. Changed the "Sign Up" button's variant from `link` to `outline` for improved visibility.
* [`app/register.tsx`](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L176-R190): Replaced the `HStack` component with a `VStack` for vertical alignment of buttons. Similarly, updated the "Sign In" button's variant from `link` to `outline` for consistency.