### PR TITLE
fix: ensure only moderators can leave accommodation when alone

### DIFF
--- a/app/(protected)/(tabs)/profile/index.tsx
+++ b/app/(protected)/(tabs)/profile/index.tsx
@@ -98,7 +98,7 @@ export default function ProfileScreen() {
   };
 
   const handleLeaveAccommodation = () => {
-    if (moderators.length === 1) {
+    if (moderators.length === 1 && user && user.role === "moderator") {
       cannotLeave();
     } else {
       leaveAccommodation();


### PR DESCRIPTION
This pull request includes a small but important change to the `ProfileScreen` component in `app/(protected)/(tabs)/profile/index.tsx`. The change updates the `handleLeaveAccommodation` function to include an additional condition that checks if the `user` exists and has the role of "moderator" before triggering the `cannotLeave` function.