### PR TITLE
feat: update text to french

### DIFF
--- a/app/(protected)/accommodation/join.tsx
+++ b/app/(protected)/accommodation/join.tsx
@@ -27,7 +27,9 @@ import { AuthService } from "@/services/server/auth";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 const AccessCodeSchema = z.object({
-  accessCode: z.string().min(6, "Access code must be at least 6 characters"),
+  accessCode: z
+    .string()
+    .min(6, "Le code d'accès doit faire au moins 6 caractères"),
 });
 
 export default function JoinPage() {
@@ -64,7 +66,7 @@ export default function JoinPage() {
       userService.joinAccommodationByCode(user._id, {
         code: data.accessCode,
       });
-      Alert.alert("Success", "You have joined the accommodation");
+      Alert.alert("Bravo!", "Vous avez rejoint le foyer avec succès.");
       router.replace("/");
     } catch (error: any) {
       Alert.alert("Error", error.message);
@@ -78,23 +80,23 @@ export default function JoinPage() {
       <VStack className="w-full px-10" space="xl">
         <HStack className="w-full justify-end">
           <Button variant="outline" size="md" onPress={() => logout()}>
-            <ButtonText>Logout</ButtonText>
+            <ButtonText>Se deconnecter</ButtonText>
             <ButtonIcon as={LogOutIcon} />
           </Button>
         </HStack>
         <VStack>
-          <Heading size="4xl">Join an accommodation</Heading>
-          <Text>Enter the access code to join an accommodation</Text>
+          <Heading size="4xl">Rejoindre un foyer</Heading>
+          <Text>Entrer le code d'accès afin de rejoindre le foyer</Text>
         </VStack>
 
         <FormControl className="mt-5">
           <FormControlLabel>
-            <FormControlLabelText size="lg">Access Code</FormControlLabelText>
+            <FormControlLabelText size="lg">Code d'accès</FormControlLabelText>
           </FormControlLabel>
 
           <Input className="w-full" size="lg" isInvalid={!!errors.accessCode}>
             <InputField
-              placeholder="XXXXXX"
+              placeholder="Entrez le code d'accès"
               autoCapitalize="none"
               type="text"
               value={watch("accessCode")}
@@ -106,7 +108,8 @@ export default function JoinPage() {
           </Input>
           <FormControlHelper>
             <FormControlHelperText>
-              Enter the access code to join the accommodation
+              Le code d'accès est un code unique qui vous permet de rejoindre un
+              foyer. Il est généralement fourni par l'administrateur du foyer.
             </FormControlHelperText>
           </FormControlHelper>
           {errors.accessCode && (
@@ -123,9 +126,8 @@ export default function JoinPage() {
           className="mt-5"
           variant="solid"
           size="lg"
-          isLoading={loading}
         >
-          <ButtonText>Join</ButtonText>
+          <ButtonText>Rejoindre</ButtonText>
         </Button>
       </VStack>
     </Center>

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -51,58 +51,62 @@ export default function LoginScreen() {
     <Center className="h-full w-full">
       <VStack className="w-full px-10" space="xl">
         <VStack>
-          <Heading size="4xl">Sign In</Heading>
-          <Text>Sign in to start using COABI app</Text>
+          <Heading size="4xl">Se connecter</Heading>
+          <Text>Connectez-vous pour utiliser l'application COABI</Text>
         </VStack>
 
-        <FormControl isInvalid={!!errors.username} size="lg">
-          <FormControlLabel>
-            <FormControlLabelText size="xl">Username</FormControlLabelText>
-          </FormControlLabel>
-          <Input className="my-1" size="xl">
-            <InputField
-              placeholder="Enter your username"
-              autoCapitalize="none"
-              type="text"
-              value={watch("username")}
-              onChangeText={(text) => setValue("username", text)}
-              onBlur={() => trigger("username")}
-            />
-          </Input>
-          {errors.username && (
-            <FormControlError>
-              <FormControlErrorText>
-                {errors.username.message}
-              </FormControlErrorText>
-            </FormControlError>
-          )}
-        </FormControl>
+        <VStack space="lg">
+          <FormControl isInvalid={!!errors.username} size="lg">
+            <FormControlLabel>
+              <FormControlLabelText size="xl">Identifiant</FormControlLabelText>
+            </FormControlLabel>
+            <Input size="xl">
+              <InputField
+                placeholder="Entrez votre identifiant"
+                autoCapitalize="none"
+                type="text"
+                value={watch("username")}
+                onChangeText={(text) => setValue("username", text)}
+                onBlur={() => trigger("username")}
+              />
+            </Input>
+            {errors.username && (
+              <FormControlError>
+                <FormControlErrorText>
+                  {errors.username.message}
+                </FormControlErrorText>
+              </FormControlError>
+            )}
+          </FormControl>
 
-        <FormControl isInvalid={!!errors.password} size="lg">
-          <FormControlLabel>
-            <FormControlLabelText size="xl">Password</FormControlLabelText>
-          </FormControlLabel>
-          <Input className="my-1" size="xl">
-            <InputField
-              placeholder="Enter your password"
-              type="password"
-              value={watch("password")}
-              onChangeText={(text) => setValue("password", text)}
-              onBlur={() => trigger("password")}
-            />
-          </Input>
-          {errors.password && (
-            <FormControlError>
-              <FormControlErrorText>
-                {errors.password.message}
-              </FormControlErrorText>
-            </FormControlError>
-          )}
-        </FormControl>
+          <FormControl isInvalid={!!errors.password} size="lg">
+            <FormControlLabel>
+              <FormControlLabelText size="xl">
+                Mot de passe
+              </FormControlLabelText>
+            </FormControlLabel>
+            <Input size="xl">
+              <InputField
+                placeholder="Entrez votre mot de passe"
+                type="password"
+                value={watch("password")}
+                onChangeText={(text) => setValue("password", text)}
+                onBlur={() => trigger("password")}
+              />
+            </Input>
+            {errors.password && (
+              <FormControlError>
+                <FormControlErrorText>
+                  {errors.password.message}
+                </FormControlErrorText>
+              </FormControlError>
+            )}
+          </FormControl>
+        </VStack>
 
         <VStack space="sm">
           <Button variant="solid" size="md" onPress={handleSubmit(onSubmit)}>
-            <ButtonText>Sign In</ButtonText>
+            <ButtonText>Se connecter</ButtonText>
           </Button>
           <Button
             className=""
@@ -112,7 +116,7 @@ export default function LoginScreen() {
               router.replace("/register");
             }}
           >
-            <ButtonText>Sign Up</ButtonText>
+            <ButtonText>S'inscrire</ButtonText>
           </Button>
         </VStack>
       </VStack>

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -20,6 +20,8 @@ import { Alert, SafeAreaView } from "react-native";
 import { useForm } from "react-hook-form";
 import { RegisterSchema } from "@/types/zod/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Heading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
 
 export default function RegisterPage() {
   const {
@@ -51,7 +53,7 @@ export default function RegisterPage() {
     const registration = new AuthService();
     try {
       await registration.register(data);
-      Alert.alert("Congratulations!", "Account created");
+      Alert.alert("Felicitations!", "Votre compte a été créé avec succès.");
       router.replace("/login");
       reset();
     } catch (error: any) {
@@ -63,22 +65,24 @@ export default function RegisterPage() {
     <SafeAreaView>
       <Center className="h-full w-full">
         <VStack className="w-full px-10" space="xl">
+          <VStack>
+            <Heading size="4xl">S'inscrire</Heading>
+            <Text>Créez votre compte pour utiliser l'application COABI</Text>
+          </VStack>
           <FormControl size="lg" isInvalid={!!errors.username}>
             <FormControlLabel>
-              <FormControlLabelText size="xl">Username</FormControlLabelText>
+              <FormControlLabelText size="xl">Identifiant</FormControlLabelText>
             </FormControlLabel>
-            <HStack space="md" className="w-full items-center">
-              <Input className="my-1 flex-1" size="xl">
-                <InputField
-                  placeholder="Enter your username"
-                  autoCapitalize="none"
-                  type="text"
-                  value={watch("username")}
-                  onChangeText={(text) => setValue("username", text)}
-                  onBlur={() => trigger("username")}
-                />
-              </Input>
-            </HStack>
+            <Input className="" size="xl">
+              <InputField
+                placeholder="Entrez votre identifiant"
+                autoCapitalize="none"
+                type="text"
+                value={watch("username")}
+                onChangeText={(text) => setValue("username", text)}
+                onBlur={() => trigger("username")}
+              />
+            </Input>
             {errors.username && (
               <FormControlError>
                 <FormControlErrorIcon as={AlertCircleIcon} />
@@ -93,9 +97,9 @@ export default function RegisterPage() {
             <FormControlLabel>
               <FormControlLabelText size="xl">Email</FormControlLabelText>
             </FormControlLabel>
-            <Input className="my-1" size="xl">
+            <Input size="xl">
               <InputField
-                placeholder="Enter your email"
+                placeholder="Entrez votre email"
                 autoCapitalize="none"
                 type="text"
                 value={watch("email")}
@@ -115,11 +119,13 @@ export default function RegisterPage() {
 
           <FormControl size="lg" isInvalid={!!errors.password}>
             <FormControlLabel>
-              <FormControlLabelText size="xl">Password</FormControlLabelText>
+              <FormControlLabelText size="xl">
+                Mot de passe
+              </FormControlLabelText>
             </FormControlLabel>
-            <Input className="my-1" size="xl">
+            <Input size="xl">
               <InputField
-                placeholder="Enter your password"
+                placeholder="Entrez votre mot de passe"
                 autoCapitalize="none"
                 type={showPassword ? "text" : "password"}
                 value={watch("password")}
@@ -147,12 +153,12 @@ export default function RegisterPage() {
           <FormControl size="lg" isInvalid={!!errors.confirmPassword}>
             <FormControlLabel>
               <FormControlLabelText size="xl">
-                Confirm Password
+                Confirmation du mot de passe
               </FormControlLabelText>
             </FormControlLabel>
             <Input className="my-1" size="xl">
               <InputField
-                placeholder="Confirm your password"
+                placeholder="Confirmez votre mot de passe"
                 autoCapitalize="none"
                 type={showPassword ? "text" : "password"}
                 value={watch("confirmPassword")}
@@ -179,7 +185,7 @@ export default function RegisterPage() {
 
           <VStack space="sm">
             <Button variant="solid" size="md" onPress={handleSubmit(onSubmit)}>
-              <ButtonText>Sign Up</ButtonText>
+              <ButtonText>S'inscrire</ButtonText>
             </Button>
             <Button
               className=""
@@ -189,7 +195,7 @@ export default function RegisterPage() {
                 router.replace("/login");
               }}
             >
-              <ButtonText>Sign In</ButtonText>
+              <ButtonText>Se connecter</ButtonText>
             </Button>
           </VStack>
         </VStack>

--- a/types/zod/auth.ts
+++ b/types/zod/auth.ts
@@ -5,19 +5,23 @@ const BaseRegisterSchema = z
   .object({
     username: z
       .string()
-      .max(50, "Keep under 50 characters please")
-      .nonempty("Required"),
+      .max(50, "L'identifiant doit faire moins de 50 caractères")
+      .nonempty("L'identifiant est requis"),
     password: z
       .string()
-      .min(8, "Password must be at least 8 characters long")
-      .max(72, "Password must be at most 72 characters long")
-      .nonempty("Required"),
-    confirmPassword: z.string(),
+      .min(8, "Le mot de passe doit faire au moins 8 caractères")
+      .max(72, "Le mot de passe doit faire moins de 72 caractères")
+      .nonempty("Le mot de passe est requis"),
+    confirmPassword: z
+      .string()
+      .min(8, "Le mot de passe doit faire au moins 8 caractères")
+      .max(72, "Le mot de passe doit faire moins de 72 caractères")
+      .nonempty("La confirmation du mot de passe est requise"),
     email: z
       .string()
-      .nonempty("Required")
-      .email("Email is not valid")
-      .max(50, "Keep under 50 characters please"),
+      .nonempty("L'email est requis")
+      .email("L'email n'est pas valide")
+      .max(50, "L'email doit faire moins de 50 caractères"),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords must match",
@@ -29,8 +33,8 @@ export const RegisterSchema = BaseRegisterSchema;
 export const RegisterResponseSchema = UserResponseSchema;
 
 const BaseLoginSchema = z.object({
-  username: z.string().nonempty("Required"),
-  password: z.string().nonempty("Required"),
+  username: z.string().nonempty("L'identifiant est requis"),
+  password: z.string().nonempty("Le mot de passe est requis"),
 });
 
 export const AccessSchema = BaseLoginSchema;


### PR DESCRIPTION
This pull request introduces localization updates to the authentication-related pages (`JoinPage`, `LoginScreen`, and `RegisterPage`) and validation schemas, translating all user-facing text into French. Below are the key changes grouped by theme:

### Localization Updates in UI Components:

* **Join Page (`app/(protected)/accommodation/join.tsx`)**:
  - Translated text elements like headings, button labels, and placeholders into French. For example, "Join an accommodation" is now "Rejoindre un foyer," and "Access Code" is now "Code d'accès." [[1]](diffhunk://#diff-7a8085aa6ce717f244c1bae54e48cf4bc9cf8de5175864a265106e0f8e5f13c7L67-R69) [[2]](diffhunk://#diff-7a8085aa6ce717f244c1bae54e48cf4bc9cf8de5175864a265106e0f8e5f13c7L81-R99) [[3]](diffhunk://#diff-7a8085aa6ce717f244c1bae54e48cf4bc9cf8de5175864a265106e0f8e5f13c7L109-R112) [[4]](diffhunk://#diff-7a8085aa6ce717f244c1bae54e48cf4bc9cf8de5175864a265106e0f8e5f13c7L126-R130)
  - Updated success alert messages to French (e.g., "Bravo! Vous avez rejoint le foyer avec succès.").

* **Login Screen (`app/login.tsx`)**:
  - Translated headings, placeholders, and button texts into French. For example, "Sign In" is now "Se connecter," and "Username" is now "Identifiant." [[1]](diffhunk://#diff-591565fa0176081f85d19df59ad66edd7c2c213096e3ac37d4a8585da61f7290L54-R65) [[2]](diffhunk://#diff-591565fa0176081f85d19df59ad66edd7c2c213096e3ac37d4a8585da61f7290L83-R90) [[3]](diffhunk://#diff-591565fa0176081f85d19df59ad66edd7c2c213096e3ac37d4a8585da61f7290R105-R109) [[4]](diffhunk://#diff-591565fa0176081f85d19df59ad66edd7c2c213096e3ac37d4a8585da61f7290L115-R119)

* **Register Page (`app/register.tsx`)**:
  - Added French translations for headings, placeholders, and button texts. For instance, "Sign Up" is now "S'inscrire," and "Confirm Password" is now "Confirmation du mot de passe." [[1]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L54-R56) [[2]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3R68-L81) [[3]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L96-R102) [[4]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L118-R128) [[5]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L150-R161) [[6]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L182-R188) [[7]](diffhunk://#diff-3e44adaed6a72838a853d913206973d9893b117e001e176bfb759c7f5884f8e3L192-R198)

### Localization Updates in Validation Schemas:

* **Validation Messages (`types/zod/auth.ts`)**:
  - Translated validation error messages to French for fields like `username`, `password`, `confirmPassword`, and `email`. For example, "Required" is now "L'identifiant est requis," and "Passwords must match" is now "Les mots de passe doivent correspondre." [[1]](diffhunk://#diff-14cabad533fe8b1679d718d904042ac820247de7e3a763a900d30498e8567697L8-R24) [[2]](diffhunk://#diff-14cabad533fe8b1679d718d904042ac820247de7e3a763a900d30498e8567697L32-R37)

These updates ensure a consistent French user experience across all authentication-related pages and validation errors.